### PR TITLE
Auto corrected by following Lint Ruby Layout/HeredocIndentation

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,25 +14,25 @@ CodeClimate::TestReporter.start
 SimpleCov.start
 ##############################################
 
-RdobaSimSimpleHead=<<HEAD
-#!/usr/bin/env ruby
-
-require 'rdoba'
+RdobaSimSimpleHead=<<~HEAD
+  #!/usr/bin/env ruby
+  
+  require 'rdoba'
 HEAD
 
-RdobaCodeClassDeclaration=<<HEAD
-class Cls
-  def initialize
-    log > {:variable=>"value"}
+RdobaCodeClassDeclaration=<<~HEAD
+  class Cls
+    def initialize
+      log > {:variable=>"value"}
+    end
   end
-end
 HEAD
 
-RdobaSimClsHead=<<HEAD
-#!/usr/bin/env ruby
-
-require 'rdoba'
-class Cls
+RdobaSimClsHead=<<~HEAD
+  #!/usr/bin/env ruby
+  
+  require 'rdoba'
+  class Cls
 HEAD
 
 def format str


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/HeredocIndentation

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117718) to configure it on awesomecode.io