### PR TITLE
Auto corrected by following Lint Ruby Naming/RescuedExceptionsVariableName

### DIFF
--- a/lib/rdoba/require.rb
+++ b/lib/rdoba/require.rb
@@ -50,7 +50,7 @@ public
     dbp11 "[require] <<< name = #{name}"
     begin
       res = __require__ name
-    rescue => bang
+    rescue => e
       puts "Lib internal error: #{$!.class} -> #{$!}\n\t#{$@.join("\n\t")}"
       exit
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Naming/RescuedExceptionsVariableName

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117753) to configure it on awesomecode.io