### PR TITLE
Auto corrected by following Lint Ruby Performance/BlockGivenWithExplicitBlock

### DIFF
--- a/lib/rdoba/io.rb
+++ b/lib/rdoba/io.rb
@@ -122,7 +122,7 @@ class String
         end
       end
 
-      if block_given?
+      if block
         pass = []
         (1..block.arity).each do |i| pass << "rline[#{i}]" end
         eval "yield(#{pass.join(', ')})"


### PR DESCRIPTION
Auto corrected by following Lint Ruby Performance/BlockGivenWithExplicitBlock

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117957) to configure it on awesomecode.io