### PR TITLE
Auto corrected by following Lint Ruby Style/NegatedWhile

### DIFF
--- a/lib/rdoba/io.rb
+++ b/lib/rdoba/io.rb
@@ -15,7 +15,7 @@ module Kernel
     fmt = format.split('%')
     nformat = fmt.shift
 
-    while (not fmt.empty?)
+    until (fmt.empty?)
       part = fmt.shift
       part = '%' + fmt.shift unless part
       if part =~ /([0-9 #+\-*.]*)([bcdEefGgiopsuXxP])(.*)/ and $2 == 'P'


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/NegatedWhile

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117703) to configure it on awesomecode.io