### PR TITLE
Auto corrected by following Lint Ruby Style/RedundantRegexpEscape

### DIFF
--- a/features/step_definitions/log_steps.rb
+++ b/features/step_definitions/log_steps.rb
@@ -118,11 +118,11 @@ Then /see the (variable|string|number|array|'true' value) output(?: with the :(b
           raise "Invalid answer: #{@res.chomp}, must be like " +
               "[00:00:00.000000000]{0000}(name)#{sym} variable: \"value\"" ; end
       when [:timestamp, :pid, :function_name, :function_line]
-        if @res !~ /\[\d\d:\d\d:\d\d\.\d{9}\]\{\d+\}\([^\.]+\.\d+\)#{symr} variable: "value"/
+        if @res !~ /\[\d\d:\d\d:\d\d\.\d{9}\]\{\d+\}\([^.]+\.\d+\)#{symr} variable: "value"/
           raise "Invalid answer: #{@res.chomp}, must be like " +
               "[00:00:00.000000000]{0000}(name.0)#{sym} variable: \"value\"" ; end
       when [:timestamp, :pid, :function]
-        expect( @res ).to match( /\[\d\d:\d\d:\d\d\.\d{9}\]\{\d+\}\([^:]+:[^\.]+\.\d+\)#{symr} variable: "value"/ )
+        expect( @res ).to match( /\[\d\d:\d\d:\d\d\.\d{9}\]\{\d+\}\([^:]+:[^.]+\.\d+\)#{symr} variable: "value"/ )
       else
         raise "Invalid answer: #{@res}"
       end

--- a/lib/rdoba.rb
+++ b/lib/rdoba.rb
@@ -34,7 +34,7 @@ module Rdoba
             plat = $1 == 'mswin' && 'native' || $1
             out = `ver`.encode( 'US-ASCII',
                   :invalid => :replace, :undef => :replace )
-            if out =~ /\[.* (\d+)\.([\d\.]+)\]/
+            if out =~ /\[.* (\d+)\.([\d.]+)\]/
                "windows-#{plat}-#{$1 == '5' && 'xp' || 'vista'}-#{$1}.#{$2}"
             else
                "windows-#{plat}" ; end

--- a/lib/rdoba/gem.rb
+++ b/lib/rdoba/gem.rb
@@ -19,7 +19,7 @@ module Rdoba
             plat = $1 == 'mswin' && 'native' || $1
             out = `ver`.encode( 'US-ASCII',
                   :invalid => :replace, :undef => :replace )
-            if out =~ /\[.* (\d+)\.([\d\.]+)\]/
+            if out =~ /\[.* (\d+)\.([\d.]+)\]/
                "windows-#{plat}-#{$1 == '5' && 'xp' || 'vista'}-#{$1}.#{$2}"
             else
                "windows-#{plat}" ; end

--- a/lib/rdoba/io.rb
+++ b/lib/rdoba/io.rb
@@ -21,7 +21,7 @@ module Kernel
       if part =~ /([0-9 #+\-*.]*)([bcdEefGgiopsuXxP])(.*)/ and $2 == 'P'
         keys = $1 || ''
         str = $3 || ''
-        if keys =~ /(-)?([0-9*]*)\.?([0-9\*]*)(\+?)/
+        if keys =~ /(-)?([0-9*]*)\.?([0-9*]*)(\+?)/
           value = args.shift
           indent = ' ' * ($2 == '*' ? args.shift : $2).to_i
           plain = value && value.to_p(


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RedundantRegexpEscape

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117578) to configure it on awesomecode.io