### PR TITLE
Auto corrected by following Lint Ruby Lint/ParenthesesAsGroupedExpression

### DIFF
--- a/features/step_definitions/log_steps.rb
+++ b/features/step_definitions/log_steps.rb
@@ -120,7 +120,7 @@ Then /see the (variable|string|number|array|'true' value) output(?: with the :(b
           'leave' => '>>>'
         }[notice] || '>'
     symr =
-      sym.to_s.gsub ('*') do |x|
+      sym.to_s.gsub('*') do |x|
         "\\#{x}"
       end
     prefices = match_keywords prefices


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/ParenthesesAsGroupedExpression

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/118064) to configure it on awesomecode.io