### PR TITLE
Auto corrected by following Lint Ruby Style/NumericLiteralPrefix

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -178,7 +178,7 @@ def rdoba_sim(sub, cmd, *args)
         store
         puts '-' * 15
 
-        File.chmod 0755, @tmpfile
+        File.chmod 0o755, @tmpfile
         Open3.popen3(@tmpfile) do |stdin, stdout, stderr, wait_thr|
           @out = stdout.read
           @err = stderr.read


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/NumericLiteralPrefix

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/118095) to configure it on awesomecode.io