### PR TITLE
Auto corrected by following Lint Ruby Layout/EmptyComment

### DIFF
--- a/lib/rdoba/bcd.rb
+++ b/lib/rdoba/bcd.rb
@@ -1,7 +1,6 @@
 #encoding: utf-8
 # frozen_string_literal: true
 
-#
 
 module BCD
   class ParseError < Exception


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/EmptyComment

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117953) to configure it on awesomecode.io