### PR TITLE
Auto corrected by following Lint Ruby Style/ExpandPathArguments

### DIFF
--- a/rdoba.gemspec
+++ b/rdoba.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('lib', __dir__)
 require "rdoba/_version_"
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/ExpandPathArguments

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/118053) to configure it on awesomecode.io