### PR TITLE
Auto corrected by following Lint Ruby Style/RescueStandardError

### DIFF
--- a/lib/rdoba/require.rb
+++ b/lib/rdoba/require.rb
@@ -57,7 +57,7 @@ module Kernel
     dbp11 "[require] <<< name = #{name}"
     begin
       res = __require__ name
-    rescue => bang
+    rescue StandardError => bang
       puts "Lib internal error: #{$!.class} -> #{$!}\n\t#{$@.join("\n\t")}"
       exit
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RescueStandardError

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117790) to configure it on awesomecode.io