### PR TITLE
Auto corrected by following Lint Ruby Style/OrAssignment

### DIFF
--- a/lib/rdoba/io.rb
+++ b/lib/rdoba/io.rb
@@ -18,7 +18,7 @@ module Kernel
 
     while not fmt.empty?
       part = fmt.shift
-      part = '%' + fmt.shift unless part
+      part ||= '%' + fmt.shift
       if part =~ /([0-9 #+\-*.]*)([bcdEefGgiopsuXxP])(.*)/ and $2 == 'P'
         keys = $1 || ''
         str = $3 || ''


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/OrAssignment

Click [here](https://awesomecode.io/repos/majioa/rdoba/lint_configs/ruby/117873) to configure it on awesomecode.io