### PR TITLE
Auto corrected by following Lint Ruby Parentheses

### DIFF
--- a/lib/rdoba/mixin.rb
+++ b/lib/rdoba/mixin.rb
@@ -296,7 +296,7 @@ module Rdoba
       # first # => [0,2]
       # second # => [1,3]
       #
-      def split_by()
+      def split_by
         idxs = []
         rejected = self.reject.with_index do |v, i| yield(v) && (idxs << i)end
         [self.values_at(*idxs), rejected]


### PR DESCRIPTION
Auto corrected by following Lint Ruby Parentheses

Click [here](https://awesomecode.io/repos/majioa/rdoba/config_groups/ruby/768) to configure it on awesomecode.io